### PR TITLE
added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:7.4-apache
+RUN apt-get update && \
+    apt-get install -y libonig-dev zlib1g-dev libpng-dev libjpeg-dev libfreetype6-dev libgmp-dev && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install pdo pdo_mysql mbstring gd gmp
+COPY . /var/www/html/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Apache2, MariaDB/MySQL, PHP >=7.0
  - download project or clone to /var/www/html directory
  - go to config/ folder and edit config.php file
 
+## Usage via Docker
+- clone the repository
+- replace `DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME` with your database credentials.
+- run `docker-compose up -d`
+- open your browser and go to `http://localhost:8088`
+
  ## Screenshot
 ![preview](https://raw.githubusercontent.com/nolt/acore-mini-reg-page/master/img/preview.jpg)
 ![preview](https://raw.githubusercontent.com/nolt/acore-mini-reg-page/master/img/preview2.jpg)

--- a/config/config.php
+++ b/config/config.php
@@ -1,9 +1,15 @@
 <?php
 
-class config 
-{
-    public $hostname = "localhost";
-    public $username = "root";
-    public $password = "pass";
-    public $database = "auth";
+class config {
+    public $hostname;
+    public $username;
+    public $password;
+    public $database;
+
+    public function __construct() {
+        $this->hostname = getenv('DB_HOST') ?: 'localhost';
+        $this->username = getenv('DB_USER') ?: 'root';
+        $this->password = getenv('DB_PASS') ?: 'pass';
+        $this->database = getenv('DB_NAME') ?: 'auth';
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8088:80"
+    environment:
+      DB_HOST: localhost:port
+      DB_USER: root
+      DB_PASS: pass
+      DB_NAME: auth


### PR DESCRIPTION
Hi, I would like to add docker support to your page. 

I have made a minimal change to the `config.php` file in order for it to be able to accept `ENV` variables from the `docker-compose` file.

It will work whether someone wants to run it natively and edit the config file themselves or just run it as a container and pass in the information that way.

When you run `docker compose up` it will build the dockerfile and run the app.

Thank you for looking into my request! 